### PR TITLE
Event parser updates

### DIFF
--- a/cafesite.py
+++ b/cafesite.py
@@ -10,11 +10,11 @@ app.config.from_pyfile('settings.cfg')
 @app.route('/')
 def index():
     serverdict  = get_server_status()
-    groupinfo   = get_group_info( "cafeofbrokendreams" )
+    groupinfo   = get_group_info( "cafeofbrokendreams", maxevents=1, maxnews=1 )
     eventdict   = groupinfo["events"]
     newsdict    = groupinfo["announcements"]
 
-    return render_template('index.html', serverinfo = serverdict, eventlist = eventdict[:1], newslist = newsdict[:1])
+    return render_template('index.html', serverinfo = serverdict, eventlist = eventdict, newslist = newsdict)
 
 if __name__ == "__main__":
     app.run(debug = True, host='0.0.0.0')


### PR DESCRIPTION
Here's what I've added since the last pull request:
- Query limits. We can restrict the number of items we query on the community. This improves load times significantly when the cache is out of date.
- No longer explicitly references slices in cafesite.py. We just get lists of 1 item each. This makes the system more scalable and easily changed.
- The cache refreshes if the max query limits are changed.
- Made a number of string literals in community.py into constants.
