### PR TITLE
Further event parser improvements

### DIFF
--- a/community.py
+++ b/community.py
@@ -100,8 +100,9 @@ class SteamGroup :
     data = {
       "title"     : str( bsdata.h2.string ),
       "date"      : str( _format_eventdate_for_yr( bsdata.find( "div", class_="announcement_byline" ).get_text(), datetime.date.today().year ) ),
-      "headline"  : str( bsdata.find_all( "p" )[0] ),
-      "desc"      : str( bsdata.find_all( "p" )[1] ).replace( '</br>', '' ),
+      "headline"  : str( bsdata.p ),
+      "desc"      : str( bsdata.p.find_next( "p" ) ).replace( '</br>', '' ),
+      "img"       : str( bsdata.img["src"] )
     }
     return data
 
@@ -110,7 +111,10 @@ class SteamGroup :
   def _parseEventList( req ) :
     pattern = re.compile( "#events/(\d+)" )
     bsdata = BeautifulSoup( req.read() )
-    return [re.search( pattern, e.a['href'] ).group( 1 ) for e in bsdata.find_all( "div", class_="upcoming_event" )]
+    try : 
+      return [re.search( pattern, e.a['href'] ).group( 1 ) for e in bsdata.find_all( "div", class_="upcoming_event" )]
+    except (AttributeError, IndexError) :
+      return []
 
   # reads through an xml response and builds a dict of data to construct a new announcement
   @staticmethod
@@ -128,12 +132,15 @@ class SteamGroup :
   def _parseAnnouncementList( req ) :
     pattern = "abody_(\d+)"
     bsdata = BeautifulSoup( req.read() )
-    return [re.search( pattern, e['id'] ).group( 1 ) for e in bsdata.find_all( "div", class_="bodytext" )]
+    try :
+      return [re.search( pattern, e['id'] ).group( 1 ) for e in bsdata.find_all( "div", class_="bodytext" )]
+    except (AttributeError, IndexError) :
+      return []
 
   # gets the details of a particular event by event id
   def getEventDetails( self, id ) :
     data = self._requestGroupContent( self._parseEventDetails, MODULE_EVENTS_DETAIL, id )
-    return Event( data['title'], data['date'], data['headline'], data['desc'], self.groupUrl + '/' + MODULE_EVENTS_DETAIL + '/' + id )
+    return Event( data['title'], data['date'], data['headline'], data['desc'], data['img'], self.groupUrl + '/' + MODULE_EVENTS_DETAIL + '/' + id )
 
   # gets a list of all event ids this month
   def getEventList( self, maxresults=0 ) :
@@ -177,9 +184,10 @@ class Announcement :
     self.link     = link
 
 class Event :
-  def __init__( self, title, date, headline, desc, link ) :
+  def __init__( self, title, date, headline, desc, img, link ) :
     self.title    = title
     self.date     = date
     self.subline  = _format_eventinfo_to_subline( headline )
     self.content  = desc
     self.link     = link
+    self.image    = img

--- a/community.py
+++ b/community.py
@@ -24,7 +24,7 @@ EXPANDED_MONTHS       = { "Jan" : "January",    # expanded form of 3 letter mont
                           "Oct" : "October",
                           "Nov" : "November",
                           "Dec" : "December" }
-MODULE_EVENTS         = "events"                # url of the events list module
+MODULE_EVENTS         = ""                      # url of the events list module
 MODULE_EVENTS_DETAIL  = "events"                # url of the event details module
 MODULE_NEWS           = "announcements"         # url of the announcement list module
 MODULE_NEWS_DETAIL    = "announcements/detail"  # url of the annoucnement details module
@@ -108,9 +108,9 @@ class SteamGroup :
   # reads through an xml response and builds a list of all event ids
   @staticmethod
   def _parseEventList( req ) :
-    pattern = "(\d+)_eventBlock"
+    pattern = re.compile( "#events/(\d+)" )
     bsdata = BeautifulSoup( req.read() )
-    return [re.search( pattern, e['id'] ).group( 1 ) for e in bsdata.find_all( "div", class_="eventBlock" )]
+    return [re.search( pattern, e.a['href'] ).group( 1 ) for e in bsdata.find_all( "div", class_="upcoming_event" )]
 
   # reads through an xml response and builds a dict of data to construct a new announcement
   @staticmethod

--- a/templates/index.html
+++ b/templates/index.html
@@ -60,6 +60,9 @@
                             <!--<span class="eventimage"><img src="/static/img/cake.png" alt="cake" /></span>-->
                             <span class="eventtitle"><a href="{{ event.link }}">{{ event.title }}</a></span>
                             <span class="eventdate">{{ event.date }}</span>
+                            {% if event.image %}
+                                <div class="eventimage"><img src="{{ event.image }}"></img></div>
+                            {% endif %}
                             <span class="eventdetails">
                                 {{ event.content|safe }}
                             </span><!-- eventdetails -->


### PR DESCRIPTION
Closes #3 #6

The event parser has been modified to be more functional. Here's what I changed:
- The event list is now read from the "upcoming events" list on the front page of a group. Previously, we read from the month by month list, which restricted our searches to events this month. Now it'll automatically exclude past events as well.
- Events are now pulled with their game logo, which is displayed along with the event text.
- Events now navigate the bs tree properly, rather than making two calls to find_all
