### PR TITLE
Fixed KeyError if server is down

### DIFF
--- a/cafesite.py
+++ b/cafesite.py
@@ -11,6 +11,10 @@ app.config.from_pyfile('settings.cfg')
 def get_map_images(serverdict):
     bg_images = {}
     for server, details in serverdict.items():
+        # Skip this server if it's down
+        if not serverdict[server].has_key( 'map' ) :
+            continue
+
         mapfilename = 'static/img/maps/{0}.jpg'.format(serverdict[server]['map'])
         map_exists = os.path.exists( mapfilename )
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,17 +4,17 @@
         {% if serverinfo != False %}
     <span class="miniheader">servers</span>
     <div id="servers">
-            {% for server in serverinfo.keys() %}
+            {% for server in serverinfo.keys() %}{% if not serverinfo[server]['error'] %}
             <div id="{{ server }}" class="server" style="background-image:url('../{{ backgrounds[server] }}');">
                 <span class="info">
                     <span class="game">{{ serverinfo[server]['gamename'] }}</span>
                     <span class="ip">
                         <a href="steam://connect/{{ serverinfo[server]['ip'] }}:{{ serverinfo[server]['port'] }}">{{ serverinfo[server]['ip'] }}:{{ serverinfo[server]['port'] }}</a>
                     </span>
-                    <span class="status">{% if not serverinfo[server]['error'] %}{{ serverinfo[server]['numplayers'] }}/{{ serverinfo[server]['maxplayers'] }} [<em>{{ serverinfo[server]['map'] }}</em>]{% else %}server is down!{% endif %}</span>
+                    <span class="status">{{ serverinfo[server]['numplayers'] }}/{{ serverinfo[server]['maxplayers'] }} [<em>{{ serverinfo[server]['map'] }}</em>]</span>
                 </span><!-- info -->
             </div><!-- server -->
-            {% endfor %}
+            {% endif %}{% endfor %}
     </div><!-- servers -->
         {% endif %}
     <span class="miniheader">community</span>


### PR DESCRIPTION
closes #15

Added an error check to get_map_images that confirms that a server dict
has a map key. This prevents a 500 Internal Error that would occur if a
server is down or nonresponsive.

I've also adjusted an if tag in index.html to skip a server box if the
server dict has an error rather than showing "server is down!" in a
poorly formatted box
